### PR TITLE
Allow version headers as part of batching

### DIFF
--- a/changes/unreleased/Added-20210410-204405.yaml
+++ b/changes/unreleased/Added-20210410-204405.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: Option to include a header file when batching fragments into a version file.
+custom:
+  Issue: "92"

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -15,6 +15,7 @@ import (
 type batchData struct {
 	Version        string
 	ChangesPerKind map[string][]Change
+	Header         string
 }
 
 var errNotSemanticVersion = errors.New("version string is not a valid semantic version")
@@ -135,6 +136,12 @@ func batchNewVersion(fs afero.Fs, config Config, data batchData) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if data.Header != "" {
+		versionFile.WriteString("\n")
+		versionFile.WriteString("\n")
+		versionFile.WriteString(data.Header)
 	}
 
 	for _, kind := range config.Kinds {

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -208,7 +208,10 @@ var _ = Describe("Batch", func() {
 			"removed": {{Body: "y"}, {Body: "z"}},
 		}
 
-		err = batchNewVersion(fs, testConfig, "v0.1.0", changesPerKind)
+		err = batchNewVersion(fs, testConfig, batchData{
+			Version:        "v0.1.0",
+			ChangesPerKind: changesPerKind,
+		})
 		Expect(err).To(BeNil())
 
 		expected := `## v0.1.0
@@ -229,7 +232,10 @@ var _ = Describe("Batch", func() {
 			return f, mockError
 		}
 
-		err := batchNewVersion(fs, testConfig, "v0.1.0", map[string][]Change{})
+		err := batchNewVersion(fs, testConfig, batchData{
+			Version:        "v0.1.0",
+			ChangesPerKind: map[string][]Change{},
+		})
 		Expect(err).To(Equal(mockError))
 	})
 
@@ -239,7 +245,10 @@ var _ = Describe("Batch", func() {
 
 		testConfig.VersionFormat = "{{juuunk...}}"
 
-		err = batchNewVersion(fs, testConfig, "v0.1.0", map[string][]Change{})
+		err = batchNewVersion(fs, testConfig, batchData{
+			Version:        "v0.1.0",
+			ChangesPerKind: map[string][]Change{},
+		})
 		Expect(err).NotTo(BeNil())
 	})
 
@@ -249,7 +258,10 @@ var _ = Describe("Batch", func() {
 
 		testConfig.KindFormat = "{{randoooom../././}}"
 
-		err = batchNewVersion(fs, testConfig, "v0.1.0", map[string][]Change{})
+		err = batchNewVersion(fs, testConfig, batchData{
+			Version:        "v0.1.0",
+			ChangesPerKind: map[string][]Change{},
+		})
 		Expect(err).NotTo(BeNil())
 	})
 
@@ -259,7 +271,10 @@ var _ = Describe("Batch", func() {
 
 		testConfig.ChangeFormat = "{{not.valid.syntax....}}"
 
-		err = batchNewVersion(fs, testConfig, "v0.1.0", map[string][]Change{})
+		err = batchNewVersion(fs, testConfig, batchData{
+			Version:        "v0.1.0",
+			ChangesPerKind: map[string][]Change{},
+		})
 		Expect(err).NotTo(BeNil())
 	})
 
@@ -282,86 +297,12 @@ var _ = Describe("Batch", func() {
 			"removed": {{Body: "y"}, {Body: "z"}},
 		}
 
-		err = batchNewVersion(fs, testConfig, "v0.1.0", changesPerKind)
+		err = batchNewVersion(fs, testConfig, batchData{
+			Version:        "v0.1.0",
+			ChangesPerKind: changesPerKind,
+		})
 		Expect(err).To(Equal(mockError))
 	})
-
-	/*
-		It("returns error when failing to execute version template", func() {
-			err := afs.MkdirAll("news", 0644)
-			Expect(err).To(BeNil())
-
-			vFile := newMockFile(fs, "v0.1.0.md")
-
-			fs.mockCreate = func(path string) (afero.File, error) {
-				return vFile, nil
-			}
-
-			vFile.mockWrite = func(data []byte) (int, error) {
-				return len(data), mockError
-			}
-
-			changesPerKind := map[string][]Change{
-				"added":   {{Body: "w"}, {Body: "x"}},
-				"removed": {{Body: "y"}, {Body: "z"}},
-			}
-
-			err = batchNewVersion(fs, testConfig, "v0.1.0", changesPerKind)
-			Expect(err).To(Equal(mockError))
-		})
-
-		It("returns error when failing to execute kind template", func() {
-			err := afs.MkdirAll("news", 0644)
-			Expect(err).To(BeNil())
-
-			vFile := newMockFile(fs, "v0.1.0.md")
-
-			fs.mockCreate = func(path string) (afero.File, error) {
-				return vFile, nil
-			}
-
-			vFile.mockWrite = func(data []byte) (int, error) {
-				if strings.HasPrefix(string(data), "### ") {
-					return len(data), mockError
-				}
-				return vFile.memFile.Write(data)
-			}
-
-			changesPerKind := map[string][]Change{
-				"added":   {{Body: "w"}, {Body: "x"}},
-				"removed": {{Body: "y"}, {Body: "z"}},
-			}
-
-			err = batchNewVersion(fs, testConfig, "v0.1.0", changesPerKind)
-			Expect(err).To(Equal(mockError))
-		})
-
-		It("returns error when failing to execute change template", func() {
-			err := afs.MkdirAll("news", 0644)
-			Expect(err).To(BeNil())
-
-			vFile := newMockFile(fs, "v0.1.0.md")
-
-			fs.mockCreate = func(path string) (afero.File, error) {
-				return vFile, nil
-			}
-
-			vFile.mockWrite = func(data []byte) (int, error) {
-				if strings.HasPrefix(string(data), "*") {
-					return len(data), mockError
-				}
-				return vFile.memFile.Write(data)
-			}
-
-			changesPerKind := map[string][]Change{
-				"added":   {{Body: "w"}, {Body: "x"}},
-				"removed": {{Body: "y"}, {Body: "z"}},
-			}
-
-			err = batchNewVersion(fs, testConfig, "v0.1.0", changesPerKind)
-			Expect(err).To(Equal(mockError))
-		})
-	*/
 
 	templateTests := []struct {
 		key    string
@@ -396,7 +337,10 @@ var _ = Describe("Batch", func() {
 				"removed": {{Body: "y"}, {Body: "z"}},
 			}
 
-			err = batchNewVersion(fs, testConfig, "v0.1.0", changesPerKind)
+			err = batchNewVersion(fs, testConfig, batchData{
+				Version:        "v0.1.0",
+				ChangesPerKind: changesPerKind,
+			})
 			Expect(err).To(Equal(mockError))
 		})
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -141,11 +141,12 @@ func (r Replacement) Execute(readFile ReadFiler, writeFile WriteFiler, data Repl
 
 // Config handles configuration for a changie project
 type Config struct {
-	ChangesDir    string `yaml:"changesDir"`
-	UnreleasedDir string `yaml:"unreleasedDir"`
-	HeaderPath    string `yaml:"headerPath"`
-	ChangelogPath string `yaml:"changelogPath"`
-	VersionExt    string `yaml:"versionExt"`
+	ChangesDir        string `yaml:"changesDir"`
+	UnreleasedDir     string `yaml:"unreleasedDir"`
+	HeaderPath        string `yaml:"headerPath"`
+	VersionHeaderPath string `yaml:"versionHeaderPath"`
+	ChangelogPath     string `yaml:"changelogPath"`
+	VersionExt        string `yaml:"versionExt"`
 	// formats
 	VersionFormat string `yaml:"versionFormat"`
 	KindFormat    string `yaml:"kindFormat"`

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -13,15 +13,17 @@ import (
 var _ = Describe("Config", func() {
 	It("should save the config", func() {
 		config := Config{
-			ChangesDir:    "Changes",
-			UnreleasedDir: "Unrel",
-			HeaderPath:    "header.tpl.md",
-			ChangelogPath: "CHANGELOG.md",
+			ChangesDir:        "Changes",
+			UnreleasedDir:     "Unrel",
+			HeaderPath:        "header.tpl.md",
+			VersionHeaderPath: "header.md",
+			ChangelogPath:     "CHANGELOG.md",
 		}
 
 		configYaml := `changesDir: Changes
 unreleasedDir: Unrel
 headerPath: header.tpl.md
+versionHeaderPath: header.md
 changelogPath: CHANGELOG.md
 versionExt: ""
 versionFormat: ""
@@ -62,6 +64,7 @@ kinds: []
 		configYaml := `changesDir: Changes
 unreleasedDir: Unrel
 headerPath: header.tpl.md
+versionHeaderPath: ""
 changelogPath: CHANGELOG.md
 versionExt: ""
 versionFormat: ""

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -330,6 +331,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/website/content/config/directories/index.md
+++ b/website/content/config/directories/index.md
@@ -34,11 +34,13 @@ type: *string*
 
 When batching change fragments into a single version file you can include a version header
 paragraph by creating a file at the path specified.
-This file must be placed in your unreleased directory.
+This file must be placed in your unreleased directory and should not be a `.yaml` file.
 This is empty by default and is considered optional and will be skipped if the file is not found.
 
 Filepath for your version header file.
 Relative to `unreleasedDir`.
+It is also possible to use the `--headerPath` parameter when using the `batch` command.
+CLI parameter has priority.
 
 ### changelogPath
 type: *string*

--- a/website/content/config/directories/index.md
+++ b/website/content/config/directories/index.md
@@ -29,6 +29,17 @@ A default header is created when initializing that follows "Keep a Changelog".
 Filepath for your changelog header file.
 Relative to `changesDir`.
 
+### versionHeaderPath
+type: *string*
+
+When batching change fragments into a single version file you can include a version header
+paragraph by creating a file at the path specified.
+This file must be placed in your unreleased directory.
+This is empty by default and is considered optional and will be skipped if the file is not found.
+
+Filepath for your version header file.
+Relative to `unreleasedDir`.
+
 ### changelogPath
 type: *string*
 


### PR DESCRIPTION
Closes #92

* Create `VersionHeaderPath` config value that will optionally take header files to be included with each version
* Add `--headerPath` parameter to batch command as an alternative
* Include version header just below version and above the first kind
