### PR TITLE
docs/install: Add instructions for Homebrew

### DIFF
--- a/website/content/guide/installation/index.md
+++ b/website/content/guide/installation/index.md
@@ -17,6 +17,16 @@ scoop bucket add repo https://github.com/miniscruff/changie
 scoop install changie
 ```
 
+## macOS with Homebrew
+
+On macOS, you can use [Homebrew](https://brew.sh/) to install by first tapping
+the repository.
+
+```
+brew tap miniscruff/changie https://github.com/miniscruff/changie
+brew install changie
+```
+
 ## Manual
 * Download from [here](https://github.com/miniscruff/changie/releases).
 * Add executable somewhere in your path depending on your platform.


### PR DESCRIPTION
Add installation instructions for macOS with Homebrew. The instructions
will have the user tap the changie repository and pull the forumla
directly from it.

