### PR TITLE
Add custom option to new

### DIFF
--- a/.changes/unreleased/Added-20220731-174813.yaml
+++ b/.changes/unreleased/Added-20220731-174813.yaml
@@ -1,5 +1,5 @@
 kind: Added
-body: kind option to new command
+body: Kind option to new command
 time: 2022-07-31T17:48:13.270829454+03:00
 custom:
   Issue: "339"

--- a/.changes/unreleased/Added-20220731-174906.yaml
+++ b/.changes/unreleased/Added-20220731-174906.yaml
@@ -1,5 +1,5 @@
 kind: Added
-body: body option to new command
+body: Body option to new command
 time: 2022-07-31T17:49:06.958627173+03:00
 custom:
   Issue: "338"

--- a/.changes/unreleased/Added-20220827-193813.yaml
+++ b/.changes/unreleased/Added-20220827-193813.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Custom option to new command
+time: 2022-08-27T19:38:13.6667299-07:00
+custom:
+  Issue: "340"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	go test -coverprofile=c.out ./...
 
+test-no-color:
+	go test -coverprofile=c.out ./... -ginkgo.noColor -test.failfast
+
 coverage: test
 	go tool cover -html=c.out
 

--- a/core/custom.go
+++ b/core/custom.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/manifoldco/promptui"
 )
@@ -20,15 +21,16 @@ const (
 )
 
 var (
-	errInvalidPromptType = errors.New("invalid prompt type")
-	errInvalidIntInput   = errors.New("invalid number")
-	errIntTooLow         = errors.New("input below minimum")
-	errIntTooHigh        = errors.New("input above maximum")
-	errInputTooLong      = errors.New("input length too long")
-	errInputTooShort     = errors.New("input length too short")
-	errInvalidEnum       = errors.New("invalid enum")
-	base10               = 10
-	bit64                = 64
+	errInvalidPromptType   = errors.New("invalid prompt type")
+	errInvalidIntInput     = errors.New("invalid number")
+	errIntTooLow           = errors.New("input below minimum")
+	errIntTooHigh          = errors.New("input above maximum")
+	errInputTooLong        = errors.New("input length too long")
+	errInputTooShort       = errors.New("input length too short")
+	errInvalidEnum         = errors.New("invalid enum")
+	errInvalidCustomFormat = errors.New("invalid custom format, must be \"Key=Value\"")
+	base10                 = 10
+	bit64                  = 64
 )
 
 type enumWrapper struct {
@@ -214,4 +216,23 @@ func (c Custom) validateEnum(input string) error {
 	}
 
 	return fmt.Errorf("%w: %s", errInvalidEnum, input)
+}
+
+// CustomMapFromStrings will parse a CLI argument of strings into a key value map
+// where each string is a key value pair separted by an equal sign.
+// Eg: Issue=15 turns into {"Issue": "15"}
+func CustomMapFromStrings(input []string) (map[string]string, error) {
+	ret := make(map[string]string)
+
+	for _, s := range input {
+		key, value, found := strings.Cut(s, "=")
+		if !found {
+			// error
+			return ret, fmt.Errorf("%w: %s", errInvalidCustomFormat, s)
+		}
+
+		ret[key] = value
+	}
+
+	return ret, nil
 }

--- a/core/custom_test.go
+++ b/core/custom_test.go
@@ -235,4 +235,22 @@ var _ = Describe("Custom", func() {
 		Expect(err).ToNot(BeNil())
 		Expect(errors.Unwrap(err)).To(Equal(errInvalidEnum))
 	})
+
+})
+
+var _ = Describe("CustomMapFromStrings", func() {
+	It("splits multiple strings", func() {
+		inputs := []string{"Issue=15", "Tag=alpha", "Owner=team-name"}
+		customValues, err := CustomMapFromStrings(inputs)
+		Expect(err).To(BeNil())
+		Expect(customValues["Issue"]).To(Equal("15"))
+		Expect(customValues["Tag"]).To(Equal("alpha"))
+		Expect(customValues["Owner"]).To(Equal("team-name"))
+	})
+
+	It("returns error on bad format", func() {
+		inputs := []string{"Issue=15", "Tag=alpha", "Ownerteam-name"}
+		_, err := CustomMapFromStrings(inputs)
+		Expect(err).To(MatchError(errInvalidCustomFormat))
+	})
 })


### PR DESCRIPTION
* this completes creating a change fragment without any prompts

Closes #340

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected