### PR TITLE
Fix typo in custom.go

### DIFF
--- a/core/custom.go
+++ b/core/custom.go
@@ -219,7 +219,7 @@ func (c Custom) validateEnum(input string) error {
 }
 
 // CustomMapFromStrings will parse a CLI argument of strings into a key value map
-// where each string is a key value pair separted by an equal sign.
+// where each string is a key value pair separated by an equal sign.
 // Eg: Issue=15 turns into {"Issue": "15"}
 func CustomMapFromStrings(input []string) (map[string]string, error) {
 	ret := make(map[string]string)


### PR DESCRIPTION



**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
separted -> separated

