### PR TITLE
auto version when batching

### DIFF
--- a/.changes/unreleased/Added-20230126-013735.yaml
+++ b/.changes/unreleased/Added-20230126-013735.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Auto mode to batch and new which uses kind configs to automatically determine
+  the next bump level
+time: 2023-01-26T01:37:35.7290684-08:00
+custom:
+  Issue: "439"

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -8,11 +8,17 @@ kindFormat: '### {{.Kind}}'
 changeFormat: '* [#{{.Custom.Issue}}](https://github.com/miniscruff/changie/issues/{{.Custom.Issue}}) {{.Body}}'
 kinds:
   - label: Added
+    auto: minor
   - label: Changed
+    auto: major
   - label: Deprecated
+    auto: patch
   - label: Removed
+    auto: major
   - label: Fixed
+    auto: patch
   - label: Security
+    auto: patch
 newlines:
   afterChangelogHeader: 1
   afterKind: 1

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -2,11 +2,6 @@ name: Generate release pull request
 
 on:
   workflow_dispatch:
-    inputs:
-      next-version:
-        description: 'Next version use vX.Y.Z, patch, minor or major'
-        default: 'patch'
-        required: true
 
 jobs:
   generate-pr:
@@ -18,11 +13,11 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Batch and merge
       run: |
-        go run main.go batch ${{ github.event.inputs.next-version }}
+        go run main.go batch auto
         go run main.go merge
         echo RELEASE_VERSION=$(go run main.go latest) >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,9 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.45
+        # Required: the version of golangci-lint is required and must be specified
+        # without patch version: we always use the latest patch version.
+        version: v1.50
 
     - name: Gen
       run: make gen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Check out code
       uses: actions/checkout@v3

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -176,7 +176,6 @@ func getBatchData(
 	afs afero.Afero,
 	version string,
 	changePaths []string,
-	batcher BatchPipeliner,
 ) (*core.BatchData, error) {
 	previousVersion, err := core.GetLatestVersion(afs.ReadDir, config, false)
 	if err != nil {
@@ -194,7 +193,7 @@ func getBatchData(
 		version,
 		batchPrereleaseFlag,
 		batchMetaFlag,
-        allChanges,
+		allChanges,
 	)
 	if err != nil {
 		return nil, err
@@ -221,7 +220,7 @@ func batchPipeline(batcher BatchPipeliner, afs afero.Afero, version string) erro
 		return err
 	}
 
-	data, err := getBatchData(config, afs, version, batchIncludeDirs, batcher)
+	data, err := getBatchData(config, afs, version, batchIncludeDirs)
 	if err != nil {
 		return err
 	}

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -17,7 +17,7 @@ import (
 
 type BatchPipeliner interface {
 	// afs afero.Afero should be part of struct
-	GetChanges(config core.Config, searchPaths []string) ([]core.Change, error)
+	// GetChanges(config core.Config, searchPaths []string) ([]core.Change, error)
 	WriteTemplate(
 		writer io.Writer,
 		template string,
@@ -65,11 +65,14 @@ var (
 )
 
 var batchCmd = &cobra.Command{
-	Use:   "batch version|major|minor|patch",
+	Use:   "batch version|major|minor|patch|auto",
 	Short: "Batch unreleased changes into a single changelog",
 	Long: `Merges all unreleased changes into one version changelog.
 
-Can use major, minor or patch as version to use the latest release and bump.
+Batch takes one argument for the next version to use, below are possible options.
+* A specific semantic version value, with optional prefix
+* Major, minor or patch to bump one level by one
+* Auto which will automatically bump based on what changes were found
 
 The new version changelog can then be modified with extra descriptions,
 context or with custom tweaks before merging into the main file.
@@ -180,18 +183,19 @@ func getBatchData(
 		return nil, err
 	}
 
+	allChanges, err := core.GetChanges(config, changePaths, afs.ReadDir, afs.ReadFile)
+	if err != nil {
+		return nil, err
+	}
+
 	currentVersion, err := core.GetNextVersion(
 		afs.ReadDir,
 		config,
 		version,
 		batchPrereleaseFlag,
 		batchMetaFlag,
+        allChanges,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	allChanges, err := batcher.GetChanges(config, changePaths)
 	if err != nil {
 		return nil, err
 	}
@@ -353,6 +357,7 @@ func batchPipeline(batcher BatchPipeliner, afs afero.Afero, version string) erro
 	return nil
 }
 
+/*
 func (b *standardBatchPipeline) GetChanges(
 	config core.Config,
 	searchPaths []string,
@@ -378,6 +383,7 @@ func (b *standardBatchPipeline) GetChanges(
 
 	return changes, nil
 }
+*/
 
 func (b *standardBatchPipeline) WriteTemplate(
 	writer io.Writer,

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -60,12 +60,30 @@ func runInit(cmd *cobra.Command, args []string) error {
 		KindFormat:    "### {{.Kind}}",
 		ChangeFormat:  "* {{.Body}}",
 		Kinds: []core.KindConfig{
-			{Label: "Added"},
-			{Label: "Changed"},
-			{Label: "Deprecated"},
-			{Label: "Removed"},
-			{Label: "Fixed"},
-			{Label: "Security"},
+			{
+				Label:     "Added",
+				AutoLevel: core.MinorLevel,
+			},
+			{
+				Label:     "Changed",
+				AutoLevel: core.MajorLevel,
+			},
+			{
+				Label:     "Deprecated",
+				AutoLevel: core.PatchLevel,
+			},
+			{
+				Label:     "Removed",
+				AutoLevel: core.MajorLevel,
+			},
+			{
+				Label:     "Fixed",
+				AutoLevel: core.PatchLevel,
+			},
+			{
+				Label:     "Security",
+				AutoLevel: core.PatchLevel,
+			},
 		},
 		Newlines: core.NewlinesConfig{
 			AfterChangelogHeader:   1,

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -17,10 +17,12 @@ var (
 )
 
 var nextCmd = &cobra.Command{
-	Use:   "next major|minor|patch",
+	Use:   "next major|minor|patch|auto",
 	Short: "Next echos the next version based on semantic versioning",
 	Long: `Next increments version based on semantic versioning.
 Check latest version and increment part (major, minor, patch).
+If auto is used, it will try and find the next version based on what kinds of changes are
+currently unreleased.
 Echo the next release version number to be used by CI tools or other commands like batch.`,
 	ValidArgs: []string{"major", "minor", "patch", "auto"},
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -76,8 +76,8 @@ func nextPipeline(
 		return err
 	}
 
-    var changes []core.Change
-    // only worry about loading changes, if we are in auto mode
+	var changes []core.Change
+	// only worry about loading changes, if we are in auto mode
 	if part == core.AutoLevel {
 		changes, err = core.GetChanges(config, includeDirs, afs.ReadDir, afs.ReadFile)
 		if err != nil {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -11,6 +11,7 @@ import (
 )
 
 var (
+	nextIncludeDirs    []string = nil
 	nextPrereleaseFlag []string = nil
 	nextMetaFlag       []string = nil
 )
@@ -21,12 +22,18 @@ var nextCmd = &cobra.Command{
 	Long: `Next increments version based on semantic versioning.
 Check latest version and increment part (major, minor, patch).
 Echo the next release version number to be used by CI tools or other commands like batch.`,
-	ValidArgs: []string{"major", "minor", "patch"},
+	ValidArgs: []string{"major", "minor", "patch", "auto"},
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	RunE:      runNext,
 }
 
 func init() {
+	nextCmd.Flags().StringSliceVarP(
+		&nextIncludeDirs,
+		"include", "i",
+		nil,
+		"Include extra directories to search for change files, relative to change directory",
+	)
 	nextCmd.Flags().StringSliceVarP(
 		&nextPrereleaseFlag,
 		"prerelease", "p",
@@ -53,16 +60,30 @@ func runNext(cmd *cobra.Command, args []string) error {
 		strings.ToLower(args[0]),
 		nextPrereleaseFlag,
 		nextMetaFlag,
+		nextIncludeDirs,
 	)
 }
 
-func nextPipeline(afs afero.Afero, writer io.Writer, part string, prerelease, meta []string) error {
+func nextPipeline(
+	afs afero.Afero,
+	writer io.Writer,
+	part string,
+	prerelease, meta, includeDirs []string) error {
 	config, err := core.LoadConfig(afs.ReadFile)
 	if err != nil {
 		return err
 	}
 
-	next, err := core.GetNextVersion(afs.ReadDir, config, part, prerelease, meta)
+    var changes []core.Change
+    // only worry about loading changes, if we are in auto mode
+	if part == core.AutoLevel {
+		changes, err = core.GetChanges(config, includeDirs, afs.ReadDir, afs.ReadFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	next, err := core.GetNextVersion(afs.ReadDir, config, part, prerelease, meta, changes)
 	if err != nil {
 		return err
 	}

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -40,12 +40,12 @@ func TestNextVersionWithPatch(t *testing.T) {
 
 func TestNextVersionWithAuto(t *testing.T) {
 	cfg := nextTestConfig()
-    cfg.Kinds = []core.KindConfig{
-        {
-            Label: "Feature",
-            AutoLevel: core.MinorLevel,
-        },
-    }
+	cfg.Kinds = []core.KindConfig{
+		{
+			Label:     "Feature",
+			AutoLevel: core.MinorLevel,
+		},
+	}
 
 	builder := strings.Builder{}
 	_, afs := then.WithAferoFSConfig(t, cfg)
@@ -54,16 +54,17 @@ func TestNextVersionWithAuto(t *testing.T) {
 	then.CreateFile(t, afs, "chgs", "v0.1.0.md")
 	then.CreateFile(t, afs, "chgs", "head.tpl.md")
 
-    minorChange := core.Change{
-        Kind: "Feature",
-    }
-    var changeBytes bytes.Buffer
-    minorChange.Write(&changeBytes)
-    then.WriteFile(t, afs, changeBytes.Bytes(), cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
+	var changeBytes bytes.Buffer
+
+	minorChange := core.Change{
+		Kind: "Feature",
+	}
+	then.Nil(t, minorChange.Write(&changeBytes))
+	then.WriteFile(t, afs, changeBytes.Bytes(), cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
 
 	err := nextPipeline(afs, &builder, "auto", nil, nil, nil)
 	then.Nil(t, err)
-    then.Equals(t, "v0.2.0", builder.String())
+	then.Equals(t, "v0.2.0", builder.String())
 }
 
 func TestNextVersionWithPrereleaseAndMeta(t *testing.T) {
@@ -98,7 +99,7 @@ func TestErrorNextPartNotSupported(t *testing.T) {
 }
 
 func TestErrorNextUnableToGetChanges(t *testing.T) {
-    cfg := nextTestConfig()
+	cfg := nextTestConfig()
 	builder := strings.Builder{}
 	_, afs := then.WithAferoFSConfig(t, cfg)
 

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -8,20 +9,22 @@ import (
 	"github.com/miniscruff/changie/then"
 )
 
-var nextTestConfig = &core.Config{
-	ChangesDir:    "chgs",
-	UnreleasedDir: "unrel",
-	HeaderPath:    "head.tpl.md",
-	ChangelogPath: "changelog.md",
-	VersionExt:    "md",
-	VersionFormat: "",
-	KindFormat:    "",
-	ChangeFormat:  "",
-	Kinds:         []core.KindConfig{},
+func nextTestConfig() *core.Config {
+	return &core.Config{
+		ChangesDir:    "chgs",
+		UnreleasedDir: "unrel",
+		HeaderPath:    "head.tpl.md",
+		ChangelogPath: "changelog.md",
+		VersionExt:    "md",
+		VersionFormat: "",
+		KindFormat:    "",
+		ChangeFormat:  "",
+		Kinds:         []core.KindConfig{},
+	}
 }
 
 func TestNextVersionWithPatch(t *testing.T) {
-	_, afs := then.WithAferoFSConfig(t, nextTestConfig)
+	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
 	builder := strings.Builder{}
 
 	// major and minor are not tested directly
@@ -30,20 +33,48 @@ func TestNextVersionWithPatch(t *testing.T) {
 	then.CreateFile(t, afs, "chgs", "v0.1.0.md")
 	then.CreateFile(t, afs, "chgs", "head.tpl.md")
 
-	err := nextPipeline(afs, &builder, "patch", nil, nil)
+	err := nextPipeline(afs, &builder, "patch", nil, nil, nil)
 	then.Nil(t, err)
 	then.Equals(t, "v0.1.1", builder.String())
 }
 
+func TestNextVersionWithAuto(t *testing.T) {
+	cfg := nextTestConfig()
+    cfg.Kinds = []core.KindConfig{
+        {
+            Label: "Feature",
+            AutoLevel: core.MinorLevel,
+        },
+    }
+
+	builder := strings.Builder{}
+	_, afs := then.WithAferoFSConfig(t, cfg)
+
+	then.CreateFile(t, afs, "chgs", "v0.0.1.md")
+	then.CreateFile(t, afs, "chgs", "v0.1.0.md")
+	then.CreateFile(t, afs, "chgs", "head.tpl.md")
+
+    minorChange := core.Change{
+        Kind: "Feature",
+    }
+    var changeBytes bytes.Buffer
+    minorChange.Write(&changeBytes)
+    then.WriteFile(t, afs, changeBytes.Bytes(), cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
+
+	err := nextPipeline(afs, &builder, "auto", nil, nil, nil)
+	then.Nil(t, err)
+    then.Equals(t, "v0.2.0", builder.String())
+}
+
 func TestNextVersionWithPrereleaseAndMeta(t *testing.T) {
-	_, afs := then.WithAferoFSConfig(t, nextTestConfig)
+	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
 	builder := strings.Builder{}
 
 	then.CreateFile(t, afs, "chgs", "v0.0.1.md")
 	then.CreateFile(t, afs, "chgs", "v0.1.0.md")
 	then.CreateFile(t, afs, "chgs", "head.tpl.md")
 
-	err := nextPipeline(afs, &builder, "patch", []string{"b1"}, []string{"hash"})
+	err := nextPipeline(afs, &builder, "patch", []string{"b1"}, []string{"hash"}, nil)
 	then.Nil(t, err)
 	then.Equals(t, "v0.1.1-b1+hash", builder.String())
 }
@@ -52,25 +83,38 @@ func TestErrorNextVersionBadConfig(t *testing.T) {
 	_, afs := then.WithAferoFS()
 	builder := strings.Builder{}
 
-	err := nextPipeline(afs, &builder, "major", nil, nil)
+	err := nextPipeline(afs, &builder, "major", nil, nil, nil)
 	then.NotNil(t, err)
 }
 
 func TestErrorNextPartNotSupported(t *testing.T) {
-	_, afs := then.WithAferoFSConfig(t, nextTestConfig)
+	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
 	builder := strings.Builder{}
 
 	then.CreateFile(t, afs, "chgs", "v0.0.1.md")
 
-	err := nextPipeline(afs, &builder, "notsupported", nil, nil)
+	err := nextPipeline(afs, &builder, "notsupported", nil, nil, nil)
+	then.NotNil(t, err)
+}
+
+func TestErrorNextUnableToGetChanges(t *testing.T) {
+    cfg := nextTestConfig()
+	builder := strings.Builder{}
+	_, afs := then.WithAferoFSConfig(t, cfg)
+
+	aVer := []byte("not a valid change")
+	then.WriteFile(t, afs, aVer, cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
+
+	// bad yaml will fail to load changes
+	err := nextPipeline(afs, &builder, "auto", nil, nil, nil)
 	then.NotNil(t, err)
 }
 
 func TestErrorNextUnableToGetVersions(t *testing.T) {
-	_, afs := then.WithAferoFSConfig(t, nextTestConfig)
+	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
 	builder := strings.Builder{}
 
 	// no files, means bad read for get versions
-	err := nextPipeline(afs, &builder, "major", nil, nil)
+	err := nextPipeline(afs, &builder, "major", nil, nil, nil)
 	then.NotNil(t, err)
 }

--- a/core/config.go
+++ b/core/config.go
@@ -58,7 +58,7 @@ type KindConfig struct {
 	SkipGlobalPost bool `yaml:"skipGlobalPost,omitempty" default:"false"`
 	// Auto determines what value to bump when using `batch auto` or `next auto`.
 	// Possible values are major, minor or patch and the highest one is used if
-    // multiple changes are found.
+	// multiple changes are found.
 	// example: yaml
 	// auto: minor
 	AutoLevel string `yaml:"auto,omitempty"`

--- a/core/config.go
+++ b/core/config.go
@@ -11,10 +11,18 @@ import (
 	"github.com/miniscruff/changie/shared"
 )
 
-const configEnvVar = "CHANGIE_CONFIG_PATH"
-const CreateFileMode os.FileMode = 0644
-const CreateDirMode os.FileMode = 0755
-const timeFormat string = "20060102-150405"
+const (
+	configEnvVar        = "CHANGIE_CONFIG_PATH"
+	timeFormat   string = "20060102-150405"
+
+	CreateFileMode os.FileMode = 0644
+	CreateDirMode  os.FileMode = 0755
+
+	AutoLevel  = "auto"
+	MajorLevel = "major"
+	MinorLevel = "minor"
+	PatchLevel = "patch"
+)
 
 var ConfigPaths []string = []string{
 	".changie.yaml",
@@ -48,6 +56,11 @@ type KindConfig struct {
 	SkipBody bool `yaml:"skipBody,omitempty" default:"false"`
 	// Skip global post allows skipping the parent post processing.
 	SkipGlobalPost bool `yaml:"skipGlobalPost,omitempty" default:"false"`
+	// Auto level determines what value to bump when using `batch auto`.
+	// Possible values are major, minor or patch.
+	// example: yaml
+	// auto: minor
+	AutoLevel string `yaml:"auto,omitempty"`
 }
 
 func (kc KindConfig) String() string {

--- a/core/config.go
+++ b/core/config.go
@@ -56,8 +56,9 @@ type KindConfig struct {
 	SkipBody bool `yaml:"skipBody,omitempty" default:"false"`
 	// Skip global post allows skipping the parent post processing.
 	SkipGlobalPost bool `yaml:"skipGlobalPost,omitempty" default:"false"`
-	// Auto level determines what value to bump when using `batch auto` or `next auto`.
-	// Possible values are major, minor or patch.
+	// Auto determines what value to bump when using `batch auto` or `next auto`.
+	// Possible values are major, minor or patch and the highest one is used if
+    // multiple changes are found.
 	// example: yaml
 	// auto: minor
 	AutoLevel string `yaml:"auto,omitempty"`

--- a/core/config.go
+++ b/core/config.go
@@ -56,7 +56,7 @@ type KindConfig struct {
 	SkipBody bool `yaml:"skipBody,omitempty" default:"false"`
 	// Skip global post allows skipping the parent post processing.
 	SkipGlobalPost bool `yaml:"skipGlobalPost,omitempty" default:"false"`
-	// Auto level determines what value to bump when using `batch auto`.
+	// Auto level determines what value to bump when using `batch auto` or `next auto`.
 	// Possible values are major, minor or patch.
 	// example: yaml
 	// auto: minor

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-    "time"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v2"
@@ -507,6 +507,7 @@ func TestHighestAutoLevel(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tc := range []struct {
 		name     string
 		changes  []Change
@@ -582,30 +583,32 @@ func TestGetAllChanges(t *testing.T) {
 		time.Date(2017, 4, 25, 15, 20, 0, 0, time.UTC),
 		time.Date(2015, 3, 25, 10, 5, 0, 0, time.UTC),
 	}
-    aPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
-    bPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "b.yaml")
-    cPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "c.yaml")
+	aPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
+	bPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "b.yaml")
+	cPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "c.yaml")
 
-    readDir := func(dirname string) ([]os.FileInfo, error) {
-        return []os.FileInfo{
-            &then.MockFileInfo{MockName: "a.yaml"},
-            &then.MockFileInfo{MockName: "b.yaml"},
-            &then.MockFileInfo{MockName: "c.yaml"},
-        }, nil
-    }
-    readFile := func(filename string) ([]byte, error) {
-        t.Log(filename)
-        var c Change
-        switch filename {
-        case aPath:
-            c = Change{Kind: "removed", Body: "third", Time: orderedTimes[2]}
-        case bPath:
-            c = Change{Kind: "added", Body: "first", Time: orderedTimes[0]}
-        case cPath:
-            c = Change{Kind: "added", Body: "second", Time: orderedTimes[1]}
-        }
-        return yaml.Marshal(&c)
-    }
+	readDir := func(dirname string) ([]os.FileInfo, error) {
+		return []os.FileInfo{
+			&then.MockFileInfo{MockName: "a.yaml"},
+			&then.MockFileInfo{MockName: "b.yaml"},
+			&then.MockFileInfo{MockName: "c.yaml"},
+		}, nil
+	}
+	readFile := func(filename string) ([]byte, error) {
+		var c Change
+
+		switch filename {
+		case aPath:
+			c = Change{Kind: "removed", Body: "third", Time: orderedTimes[2]}
+		case bPath:
+			c = Change{Kind: "added", Body: "first", Time: orderedTimes[0]}
+		case cPath:
+			c = Change{Kind: "added", Body: "second", Time: orderedTimes[1]}
+		}
+
+		return yaml.Marshal(&c)
+	}
+
 	then.CreateFile(t, afs, cfg.ChangesDir, cfg.UnreleasedDir, "ignored.txt")
 
 	changes, err := GetChanges(*cfg, nil, readDir, readFile)
@@ -620,15 +623,16 @@ func TestBatchErrorIfUnableToReadDir(t *testing.T) {
 	_, afs := then.WithAferoFSConfig(t, cfg)
 
 	mockErr := errors.New("bad mock open")
-    readDir := func(dirname string) ([]os.FileInfo, error) {
-        return nil, mockErr
-    }
-    readFile := func(filename string) ([]byte, error) {
-        return nil, nil
-    }
+	readDir := func(dirname string) ([]os.FileInfo, error) {
+		return nil, mockErr
+	}
+	readFile := func(filename string) ([]byte, error) {
+		return nil, nil
+	}
+
 	then.CreateFile(t, afs, cfg.ChangesDir, cfg.UnreleasedDir, "ignored.txt")
 
-    _, err := GetChanges(*cfg, nil, readDir, readFile)
+	_, err := GetChanges(*cfg, nil, readDir, readFile)
 	then.Err(t, mockErr, err)
 }
 
@@ -636,17 +640,18 @@ func TestBatchErrorBadChangesFile(t *testing.T) {
 	cfg := utilsTestConfig()
 	_, afs := then.WithAferoFSConfig(t, cfg)
 
-    readDir := func(dirname string) ([]os.FileInfo, error) {
-        return []os.FileInfo{
-            &then.MockFileInfo{MockName: "a.yaml"},
-        }, nil
-    }
+	readDir := func(dirname string) ([]os.FileInfo, error) {
+		return []os.FileInfo{
+			&then.MockFileInfo{MockName: "a.yaml"},
+		}, nil
+	}
 	mockErr := errors.New("bad mock open")
-    readFile := func(filename string) ([]byte, error) {
-        return nil, mockErr
-    }
+	readFile := func(filename string) ([]byte, error) {
+		return nil, mockErr
+	}
+
 	then.CreateFile(t, afs, cfg.ChangesDir, cfg.UnreleasedDir, "ignored.txt")
 
-    _, err := GetChanges(*cfg, nil, readDir, readFile)
+	_, err := GetChanges(*cfg, nil, readDir, readFile)
 	then.Err(t, mockErr, err)
 }

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -5,12 +5,33 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+    "time"
 	"testing"
 
 	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
 
 	"github.com/miniscruff/changie/then"
 )
+
+func utilsTestConfig() *Config {
+	return &Config{
+		ChangesDir:         "news",
+		UnreleasedDir:      "future",
+		HeaderPath:         "",
+		ChangelogPath:      "news.md",
+		VersionExt:         "md",
+		VersionFormat:      "## {{.Version}}",
+		KindFormat:         "### {{.Kind}}",
+		ChangeFormat:       "* {{.Body}}",
+		FragmentFileFormat: "",
+		Kinds: []KindConfig{
+			{Label: "added"},
+			{Label: "removed"},
+			{Label: "other"},
+		},
+	}
+}
 
 func TestAppendFileAppendsTwoFiles(t *testing.T) {
 	fs, afs := then.WithAferoFS()
@@ -148,7 +169,7 @@ func TestErrorNextVersionBadReadDir(t *testing.T) {
 		return []os.FileInfo{}, mockError
 	}
 
-	ver, err := GetNextVersion(mockRead, config, "major", nil, nil)
+	ver, err := GetNextVersion(mockRead, config, "major", nil, nil, nil)
 	then.Equals(t, nil, ver)
 	then.Err(t, mockError, err)
 }
@@ -161,7 +182,7 @@ func TestErrorNextVersionBadVersion(t *testing.T) {
 		}, nil
 	}
 
-	ver, err := GetNextVersion(mockRead, config, "a", []string{}, []string{})
+	ver, err := GetNextVersion(mockRead, config, "a", []string{}, []string{}, nil)
 	then.Equals(t, ver, nil)
 	then.Err(t, ErrBadVersionOrPart, err)
 }
@@ -241,11 +262,69 @@ func TestNextVersionOptions(t *testing.T) {
 				}, nil
 			}
 
-			ver, err := GetNextVersion(mockRead, config, tc.partOrVersion, tc.prerelease, tc.meta)
+			ver, err := GetNextVersion(mockRead, config, tc.partOrVersion, tc.prerelease, tc.meta, nil)
 			then.Nil(t, err)
 			then.Equals(t, tc.expected, ver.Original())
 		})
 	}
+}
+
+func TestNextVersionOptionsWithAuto(t *testing.T) {
+	config := Config{
+		Kinds: []KindConfig{
+			{
+				Label:     "patch",
+				AutoLevel: PatchLevel,
+			},
+			{
+				Label:     "minor",
+				AutoLevel: MinorLevel,
+			},
+			{
+				Label:     "major",
+				AutoLevel: MajorLevel,
+			},
+		},
+	}
+	latestVersion := "v0.2.3"
+	mockRead := func(dirname string) ([]os.FileInfo, error) {
+		return []os.FileInfo{
+			&then.MockFileInfo{MockName: latestVersion + ".md"},
+		}, nil
+	}
+	changes := []Change{
+		{
+			Kind: "minor",
+		},
+	}
+
+	ver, err := GetNextVersion(mockRead, config, "auto", nil, nil, changes)
+	then.Nil(t, err)
+	then.Equals(t, "v0.3.0", ver.Original())
+}
+
+func TestErrorNextVersionAutoMissingKind(t *testing.T) {
+	config := Config{
+		Kinds: []KindConfig{
+			{
+				Label: "missing",
+			},
+		},
+	}
+	latestVersion := "v0.2.3"
+	mockRead := func(dirname string) ([]os.FileInfo, error) {
+		return []os.FileInfo{
+			&then.MockFileInfo{MockName: latestVersion + ".md"},
+		}, nil
+	}
+	changes := []Change{
+		{
+			Kind: "missing",
+		},
+	}
+
+	_, err := GetNextVersion(mockRead, config, "auto", nil, nil, changes)
+	then.Err(t, ErrMissingAutoLevel, err)
 }
 
 func TestErrorNextVersionBadPrerelease(t *testing.T) {
@@ -256,7 +335,7 @@ func TestErrorNextVersionBadPrerelease(t *testing.T) {
 		}, nil
 	}
 
-	_, err := GetNextVersion(mockRead, config, "patch", []string{"0005"}, nil)
+	_, err := GetNextVersion(mockRead, config, "patch", []string{"0005"}, nil, nil)
 	then.NotNil(t, err)
 }
 
@@ -268,7 +347,7 @@ func TestErrorNextVersionBadMeta(t *testing.T) {
 		}, nil
 	}
 
-	_, err := GetNextVersion(mockRead, config, "patch", nil, []string{"&&*&"})
+	_, err := GetNextVersion(mockRead, config, "patch", nil, []string{"&&*&"}, nil)
 	then.NotNil(t, err)
 }
 
@@ -279,23 +358,23 @@ func TestCanFindChangeFiles(t *testing.T) {
 	}
 	mockRead := func(dirname string) ([]os.FileInfo, error) {
 		switch dirname {
-		case ".chng/alpha":
+		case filepath.Join(".chng", "alpha"):
 			return []os.FileInfo{
 				&then.MockFileInfo{MockName: "c.yaml"},
 				&then.MockFileInfo{MockName: "d.yaml"},
 			}, nil
-		case ".chng/beta":
+		case filepath.Join(".chng", "beta"):
 			return []os.FileInfo{
 				&then.MockFileInfo{MockName: "e.yaml"},
 				&then.MockFileInfo{MockName: "f.yaml"},
 				&then.MockFileInfo{MockName: "ignored.md"},
 			}, nil
-		case ".chng/unrel":
+		case filepath.Join(".chng", "unrel"):
 			return []os.FileInfo{
 				&then.MockFileInfo{MockName: "a.yaml"},
 				&then.MockFileInfo{MockName: "b.yaml"},
 			}, nil
-		case ".chng/ignored":
+		case filepath.Join(".chng", "ignored"):
 			return []os.FileInfo{
 				&then.MockFileInfo{MockName: "g.yaml"},
 			}, nil
@@ -394,4 +473,180 @@ func TestLoadEnvsWithPrefix(t *testing.T) {
 
 	envs := LoadEnvVars(&cfg, vars)
 	then.MapEquals(t, expected, envs)
+}
+
+func TestValidBumpLevel(t *testing.T) {
+	for _, lvl := range []string{
+		MajorLevel,
+		MinorLevel,
+		PatchLevel,
+		AutoLevel,
+	} {
+		then.True(t, ValidBumpLevel(lvl))
+	}
+}
+
+func TestInvalidBumpLevel(t *testing.T) {
+	then.False(t, ValidBumpLevel("invalid"))
+}
+
+func TestHighestAutoLevel(t *testing.T) {
+	cfg := Config{
+		Kinds: []KindConfig{
+			{
+				Label:     "patch",
+				AutoLevel: PatchLevel,
+			},
+			{
+				Label:     "minor",
+				AutoLevel: MinorLevel,
+			},
+			{
+				Label:     "major",
+				AutoLevel: MajorLevel,
+			},
+		},
+	}
+	for _, tc := range []struct {
+		name     string
+		changes  []Change
+		expected string
+	}{
+		{
+			name:     "single patch",
+			expected: PatchLevel,
+			changes: []Change{
+				{
+					Kind: "patch",
+				},
+			},
+		},
+		{
+			name:     "patch and minor",
+			expected: MinorLevel,
+			changes: []Change{
+				{
+					Kind: "patch",
+				},
+				{
+					Kind: "minor",
+				},
+			},
+		},
+		{
+			name:     "major, minor and patch",
+			expected: MajorLevel,
+			changes: []Change{
+				{
+					Kind: "patch",
+				},
+				{
+					Kind: "minor",
+				},
+				{
+					Kind: "major",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := HighestAutoLevel(cfg, tc.changes)
+			then.Nil(t, err)
+			then.Equals(t, tc.expected, res)
+		})
+	}
+}
+
+func TestErrorHighestAutoLevelMissingKindConfig(t *testing.T) {
+	cfg := Config{
+		Kinds: []KindConfig{
+			{
+				Label: "missing",
+			},
+		},
+	}
+	changes := []Change{
+		{
+			Kind: "missing",
+		},
+	}
+	_, err := HighestAutoLevel(cfg, changes)
+	then.Err(t, ErrMissingAutoLevel, err)
+}
+
+func TestGetAllChanges(t *testing.T) {
+	cfg := utilsTestConfig()
+	_, afs := then.WithAferoFSConfig(t, cfg)
+	orderedTimes := []time.Time{
+		time.Date(2019, 5, 25, 20, 45, 0, 0, time.UTC),
+		time.Date(2017, 4, 25, 15, 20, 0, 0, time.UTC),
+		time.Date(2015, 3, 25, 10, 5, 0, 0, time.UTC),
+	}
+    aPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
+    bPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "b.yaml")
+    cPath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir, "c.yaml")
+
+    readDir := func(dirname string) ([]os.FileInfo, error) {
+        return []os.FileInfo{
+            &then.MockFileInfo{MockName: "a.yaml"},
+            &then.MockFileInfo{MockName: "b.yaml"},
+            &then.MockFileInfo{MockName: "c.yaml"},
+        }, nil
+    }
+    readFile := func(filename string) ([]byte, error) {
+        t.Log(filename)
+        var c Change
+        switch filename {
+        case aPath:
+            c = Change{Kind: "removed", Body: "third", Time: orderedTimes[2]}
+        case bPath:
+            c = Change{Kind: "added", Body: "first", Time: orderedTimes[0]}
+        case cPath:
+            c = Change{Kind: "added", Body: "second", Time: orderedTimes[1]}
+        }
+        return yaml.Marshal(&c)
+    }
+	then.CreateFile(t, afs, cfg.ChangesDir, cfg.UnreleasedDir, "ignored.txt")
+
+	changes, err := GetChanges(*cfg, nil, readDir, readFile)
+	then.Nil(t, err)
+	then.Equals(t, "second", changes[0].Body)
+	then.Equals(t, "first", changes[1].Body)
+	then.Equals(t, "third", changes[2].Body)
+}
+
+func TestBatchErrorIfUnableToReadDir(t *testing.T) {
+	cfg := utilsTestConfig()
+	_, afs := then.WithAferoFSConfig(t, cfg)
+
+	mockErr := errors.New("bad mock open")
+    readDir := func(dirname string) ([]os.FileInfo, error) {
+        return nil, mockErr
+    }
+    readFile := func(filename string) ([]byte, error) {
+        return nil, nil
+    }
+	then.CreateFile(t, afs, cfg.ChangesDir, cfg.UnreleasedDir, "ignored.txt")
+
+    _, err := GetChanges(*cfg, nil, readDir, readFile)
+	then.Err(t, mockErr, err)
+}
+
+func TestBatchErrorBadChangesFile(t *testing.T) {
+	cfg := utilsTestConfig()
+	_, afs := then.WithAferoFSConfig(t, cfg)
+
+    readDir := func(dirname string) ([]os.FileInfo, error) {
+        return []os.FileInfo{
+            &then.MockFileInfo{MockName: "a.yaml"},
+        }, nil
+    }
+	mockErr := errors.New("bad mock open")
+    readFile := func(filename string) ([]byte, error) {
+        return nil, mockErr
+    }
+	then.CreateFile(t, afs, cfg.ChangesDir, cfg.UnreleasedDir, "ignored.txt")
+
+    _, err := GetChanges(*cfg, nil, readDir, readFile)
+	then.Err(t, mockErr, err)
 }


### PR DESCRIPTION
Closes #439

Auto can also be used for the next command.
This does not remove the existing major, minor, patch or specific version options.

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
Any additional info that might help get your pull request merged.
