### PR TITLE
next command uses a slightly different style for loading cobra commands

### DIFF
--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -154,7 +154,6 @@ func init() {
 		false,
 		"Force a new version file even if one already exists",
 	)
-	rootCmd.AddCommand(batchCmd)
 }
 
 func runBatch(cmd *cobra.Command, args []string) error {

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/miniscruff/changie/then"
 	"github.com/spf13/cobra"
+
+	"github.com/miniscruff/changie/then"
 )
 
 func swapInReaderOutWriter(t *testing.T, cmd *cobra.Command, inReader, outWriter *os.File) {
@@ -84,7 +85,7 @@ func testMerge(t *testing.T, cmd *cobra.Command) {
 }
 
 func TestFullRun(t *testing.T) {
-    cmd := RootCmd()
+	cmd := RootCmd()
 
 	then.WithTempDir(t)
 	inReader, inWriter, outReader, outWriter := then.WithStdInOut(t)
@@ -102,7 +103,7 @@ func TestFullRun(t *testing.T) {
 }
 
 func TestErrorNextBadInput(t *testing.T) {
-    cmd := RootCmd()
+	cmd := RootCmd()
 
 	then.WithTempDir(t)
 	testInit(t, cmd)
@@ -112,7 +113,7 @@ func TestErrorNextBadInput(t *testing.T) {
 }
 
 func TestErrorNextExactVersion(t *testing.T) {
-    cmd := RootCmd()
+	cmd := RootCmd()
 
 	then.WithTempDir(t)
 	testInit(t, cmd)

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -75,13 +75,9 @@ var genCmd = &cobra.Command{
 		writeConfigFrontMatter(file, time.Now)
 		genConfigDocs(fset, file, corePackages)
 
-		return doc.GenMarkdownTreeCustom(rootCmd, "docs/content/cli", filePrepender, linkHandler)
+		return doc.GenMarkdownTreeCustom(cmd.Root(), "docs/content/cli", filePrepender, linkHandler)
 	},
 	Hidden: true,
-}
-
-func init() {
-	rootCmd.AddCommand(genCmd)
 }
 
 func filePrepender(filename string) string {

--- a/cmd/gen_test.go
+++ b/cmd/gen_test.go
@@ -61,7 +61,7 @@ func TestCanGetFiles(t *testing.T) {
 	}
 
 	// run the gen command
-    cmd := RootCmd()
+	cmd := RootCmd()
 	cmd.SetArgs([]string{"gen"})
 	then.Nil(t, cmd.Execute())
 
@@ -74,7 +74,8 @@ func TestCanGetFiles(t *testing.T) {
 }
 
 func TestErrorGenIfContentPathIsMissing(t *testing.T) {
-    cmd := RootCmd()
+	cmd := RootCmd()
+
 	then.WithTempDir(t)
 
 	cmd.SetArgs([]string{"gen"})

--- a/cmd/gen_test.go
+++ b/cmd/gen_test.go
@@ -61,8 +61,9 @@ func TestCanGetFiles(t *testing.T) {
 	}
 
 	// run the gen command
-	rootCmd.SetArgs([]string{"gen"})
-	then.Nil(t, Execute(""))
+    cmd := RootCmd()
+	cmd.SetArgs([]string{"gen"})
+	then.Nil(t, cmd.Execute())
 
 	// test a few files exist
 	then.FileExists(t, cliDocsPath, "changie.md")
@@ -73,10 +74,11 @@ func TestCanGetFiles(t *testing.T) {
 }
 
 func TestErrorGenIfContentPathIsMissing(t *testing.T) {
+    cmd := RootCmd()
 	then.WithTempDir(t)
 
-	rootCmd.SetArgs([]string{"gen"})
-	then.NotNil(t, Execute(""))
+	cmd.SetArgs([]string{"gen"})
+	then.NotNil(t, cmd.Execute())
 }
 
 func TestErrorGenBadWriteTypesWriter(t *testing.T) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,8 +36,6 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(initCmd)
-
 	initCmd.Flags().StringVarP(&changesDir, "dir", "d", ".changes", "directory for all changes")
 	initCmd.Flags().StringVarP(
 		&changelogPath,

--- a/cmd/latest.go
+++ b/cmd/latest.go
@@ -24,8 +24,6 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(latestCmd)
-
 	latestCmd.Flags().BoolVarP(
 		&removePrefix,
 		"remove-prefix", "r",

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -32,7 +32,6 @@ func init() {
 		false,
 		"Print merged changelog instead of writing to disk, will not run replacements",
 	)
-	rootCmd.AddCommand(mergeCmd)
 }
 
 func runMerge(cmd *cobra.Command, args []string) error {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -70,7 +70,6 @@ func init() {
 		nil,
 		"Set custom values without a prompt",
 	)
-	rootCmd.AddCommand(newCmd)
 }
 
 func runNew(cmd *cobra.Command, args []string) error {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -1,77 +1,74 @@
 package cmd
 
 import (
-	"io"
 	"strings"
 
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/miniscruff/changie/core"
+	"github.com/miniscruff/changie/shared"
 )
 
-var (
-	nextIncludeDirs    []string = nil
-	nextPrereleaseFlag []string = nil
-	nextMetaFlag       []string = nil
-)
+type Next struct {
+    *cobra.Command
 
-var nextCmd = &cobra.Command{
-	Use:   "next major|minor|patch|auto",
-	Short: "Next echos the next version based on semantic versioning",
-	Long: `Next increments version based on semantic versioning.
+	// cli args
+	IncludeDirs []string
+	Prerelease  []string
+	Meta        []string
+
+
+	ReadDir  shared.ReadDirer
+	ReadFile shared.ReadFiler
+}
+
+func NewNext(readDir shared.ReadDirer, readFile shared.ReadFiler) *Next {
+	next := &Next{
+		ReadDir:  readDir,
+		ReadFile: readFile,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "next major|minor|patch|auto",
+		Short: "Next echos the next version based on semantic versioning",
+		Long: `Next increments version based on semantic versioning.
 Check latest version and increment part (major, minor, patch).
 If auto is used, it will try and find the next version based on what kinds of changes are
 currently unreleased.
 Echo the next release version number to be used by CI tools or other commands like batch.`,
-	ValidArgs: []string{"major", "minor", "patch", "auto"},
-	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-	RunE:      runNext,
-}
+		ValidArgs: []string{"major", "minor", "patch", "auto"},
+		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE:      next.Run,
+	}
 
-func init() {
-	nextCmd.Flags().StringSliceVarP(
-		&nextIncludeDirs,
+	cmd.Flags().StringSliceVarP(
+		&next.IncludeDirs,
 		"include", "i",
 		nil,
 		"Include extra directories to search for change files, relative to change directory",
 	)
-	nextCmd.Flags().StringSliceVarP(
-		&nextPrereleaseFlag,
+	cmd.Flags().StringSliceVarP(
+		&next.Prerelease,
 		"prerelease", "p",
 		nil,
 		"Prerelease values to append to version",
 	)
-	nextCmd.Flags().StringSliceVarP(
-		&nextMetaFlag,
+	cmd.Flags().StringSliceVarP(
+		&next.Meta,
 		"metadata", "m",
 		nil,
 		"Metadata values to append to version",
 	)
+    next.Command = cmd
 
-	rootCmd.AddCommand(nextCmd)
+	return next
 }
 
-func runNext(cmd *cobra.Command, args []string) error {
-	fs := afero.NewOsFs()
-	afs := afero.Afero{Fs: fs}
+func (n *Next) Run(cmd *cobra.Command, args []string) error {
+	writer := cmd.OutOrStdout()
+	part := strings.ToLower(args[0])
 
-	return nextPipeline(
-		afs,
-		cmd.OutOrStdout(),
-		strings.ToLower(args[0]),
-		nextPrereleaseFlag,
-		nextMetaFlag,
-		nextIncludeDirs,
-	)
-}
-
-func nextPipeline(
-	afs afero.Afero,
-	writer io.Writer,
-	part string,
-	prerelease, meta, includeDirs []string) error {
-	config, err := core.LoadConfig(afs.ReadFile)
+	config, err := core.LoadConfig(n.ReadFile)
 	if err != nil {
 		return err
 	}
@@ -79,13 +76,13 @@ func nextPipeline(
 	var changes []core.Change
 	// only worry about loading changes, if we are in auto mode
 	if part == core.AutoLevel {
-		changes, err = core.GetChanges(config, includeDirs, afs.ReadDir, afs.ReadFile)
+		changes, err = core.GetChanges(config, n.IncludeDirs, n.ReadDir, n.ReadFile)
 		if err != nil {
 			return err
 		}
 	}
 
-	next, err := core.GetNextVersion(afs.ReadDir, config, part, prerelease, meta, changes)
+	next, err := core.GetNextVersion(n.ReadDir, config, part, n.Prerelease, n.Meta, changes)
 	if err != nil {
 		return err
 	}

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -10,13 +10,12 @@ import (
 )
 
 type Next struct {
-    *cobra.Command
+	*cobra.Command
 
 	// cli args
 	IncludeDirs []string
 	Prerelease  []string
 	Meta        []string
-
 
 	ReadDir  shared.ReadDirer
 	ReadFile shared.ReadFiler
@@ -59,7 +58,8 @@ Echo the next release version number to be used by CI tools or other commands li
 		nil,
 		"Metadata values to append to version",
 	)
-    next.Command = cmd
+
+	next.Command = cmd
 
 	return next
 }

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -25,10 +25,10 @@ func nextTestConfig() *core.Config {
 
 func TestNextVersionWithPatch(t *testing.T) {
 	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 	builder := strings.Builder{}
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 
 	// major and minor are not tested directly
 	// as next version is tested in utils
@@ -52,9 +52,9 @@ func TestNextVersionWithAuto(t *testing.T) {
 
 	builder := strings.Builder{}
 	_, afs := then.WithAferoFSConfig(t, cfg)
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 	then.CreateFile(t, afs, "chgs", "v0.0.1.md")
 	then.CreateFile(t, afs, "chgs", "v0.1.0.md")
 	then.CreateFile(t, afs, "chgs", "head.tpl.md")
@@ -74,13 +74,13 @@ func TestNextVersionWithAuto(t *testing.T) {
 
 func TestNextVersionWithPrereleaseAndMeta(t *testing.T) {
 	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 	builder := strings.Builder{}
 
-    next.Prerelease = []string{"b1"}
-    next.Meta = []string{"hash"}
+	next.Prerelease = []string{"b1"}
+	next.Meta = []string{"hash"}
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 	then.CreateFile(t, afs, "chgs", "v0.0.1.md")
 	then.CreateFile(t, afs, "chgs", "v0.1.0.md")
 	then.CreateFile(t, afs, "chgs", "head.tpl.md")
@@ -93,9 +93,9 @@ func TestNextVersionWithPrereleaseAndMeta(t *testing.T) {
 func TestErrorNextVersionBadConfig(t *testing.T) {
 	_, afs := then.WithAferoFS()
 	builder := strings.Builder{}
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 
 	err := next.Run(next.Command, []string{"major"})
 	then.NotNil(t, err)
@@ -104,9 +104,9 @@ func TestErrorNextVersionBadConfig(t *testing.T) {
 func TestErrorNextPartNotSupported(t *testing.T) {
 	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
 	builder := strings.Builder{}
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 	then.CreateFile(t, afs, "chgs", "v0.0.1.md")
 
 	err := next.Run(next.Command, []string{"notsupported"})
@@ -117,10 +117,10 @@ func TestErrorNextUnableToGetChanges(t *testing.T) {
 	cfg := nextTestConfig()
 	builder := strings.Builder{}
 	_, afs := then.WithAferoFSConfig(t, cfg)
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 	aVer := []byte("not a valid change")
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 	then.WriteFile(t, afs, aVer, cfg.ChangesDir, cfg.UnreleasedDir, "a.yaml")
 
 	// bad yaml will fail to load changes
@@ -131,9 +131,9 @@ func TestErrorNextUnableToGetChanges(t *testing.T) {
 func TestErrorNextUnableToGetVersions(t *testing.T) {
 	_, afs := then.WithAferoFSConfig(t, nextTestConfig())
 	builder := strings.Builder{}
-    next := NewNext(afs.ReadDir, afs.ReadFile)
+	next := NewNext(afs.ReadDir, afs.ReadFile)
 
-    next.SetOut(&builder)
+	next.SetOut(&builder)
 
 	// no files, means bad read for get versions
 	err := next.Run(next.Command, []string{"major"})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 func RootCmd() *cobra.Command {
-    cmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "changie",
 		Short: "changie handles conflict-free changelog management",
 		Long: `Changie keeps your changes organized and attached to your code.
@@ -19,15 +19,15 @@ being easy to use for developers and your release team.`,
 	fs := afero.NewOsFs()
 	afs := afero.Afero{Fs: fs}
 
-    cmd.AddCommand(NewNext(afs.ReadDir, afs.ReadFile).Command)
+	cmd.AddCommand(NewNext(afs.ReadDir, afs.ReadFile).Command)
 
-    // old style adds
-    cmd.AddCommand(batchCmd)
-    cmd.AddCommand(genCmd)
-    cmd.AddCommand(initCmd)
-    cmd.AddCommand(latestCmd)
-    cmd.AddCommand(mergeCmd)
-    cmd.AddCommand(newCmd)
+	// old style adds
+	cmd.AddCommand(batchCmd)
+	cmd.AddCommand(genCmd)
+	cmd.AddCommand(initCmd)
+	cmd.AddCommand(latestCmd)
+	cmd.AddCommand(mergeCmd)
+	cmd.AddCommand(newCmd)
 
-    return cmd
+	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,20 +1,33 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
 
 // rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "changie",
-	Short: "changie handles conflict-free changelog management",
-	Long: `Changie keeps your changes organized and attached to your code.
+func RootCmd() *cobra.Command {
+    cmd := &cobra.Command{
+		Use:   "changie",
+		Short: "changie handles conflict-free changelog management",
+		Long: `Changie keeps your changes organized and attached to your code.
 
 Changie is aimed at seemlessly integrating into your release process while also
 being easy to use for developers and your release team.`,
-}
+	}
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(version string) error {
-	rootCmd.Version = version
-	return rootCmd.Execute()
+	fs := afero.NewOsFs()
+	afs := afero.Afero{Fs: fs}
+
+    cmd.AddCommand(NewNext(afs.ReadDir, afs.ReadFile).Command)
+
+    // old style adds
+    cmd.AddCommand(batchCmd)
+    cmd.AddCommand(genCmd)
+    cmd.AddCommand(initCmd)
+    cmd.AddCommand(latestCmd)
+    cmd.AddCommand(mergeCmd)
+    cmd.AddCommand(newCmd)
+
+    return cmd
 }

--- a/main.go
+++ b/main.go
@@ -11,8 +11,9 @@ import (
 var version = "dev"
 
 func main() {
-    rootCmd := cmd.RootCmd()
-    rootCmd.Version = "v" + version
+	rootCmd := cmd.RootCmd()
+	rootCmd.Version = "v" + version
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,9 @@ import (
 var version = "dev"
 
 func main() {
-	if err := cmd.Execute("v" + version); err != nil {
+    rootCmd := cmd.RootCmd()
+    rootCmd.Version = "v" + version
+	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
* this should be a little easier at managing global variables and state
* and will be easier to inject dependencies to commands

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
Part of https://github.com/miniscruff/changie/issues/71 but will need lots more work, the goal is to abstract afero into a small number of places, then replace it. Right now it is kinda sprawled everywhere.
