### PR TITLE
Option to include unreleased fragments when merging

### DIFF
--- a/.changes/unreleased/Added-20230814-203250.yaml
+++ b/.changes/unreleased/Added-20230814-203250.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Option to batch unreleased changes when merging changelogs
+time: 2023-08-14T20:32:50.506013362-07:00
+custom:
+  Issue: "503"

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -120,7 +120,9 @@ func (m *Merge) Run(cmd *cobra.Command, args []string) error {
 		// Make sure we have any changes before writing the unreleased content.
 		if len(allChanges) > 0 {
 			_ = core.WriteNewlines(writer, config.Newlines.BeforeChangelogVersion)
+			_ = core.WriteNewlines(writer, config.Newlines.BeforeVersion)
 			_, _ = writer.Write([]byte(m.UnreleasedHeader))
+			_ = core.WriteNewlines(writer, config.Newlines.AfterVersion)
 
 			// create a fake batch to write the changes
 			b := &Batch{
@@ -134,6 +136,7 @@ func (m *Merge) Run(cmd *cobra.Command, args []string) error {
 				return unrelErr
 			}
 
+			_ = core.WriteNewlines(b.writer, b.config.Newlines.EndOfVersion)
 			_ = core.WriteNewlines(writer, config.Newlines.AfterChangelogVersion)
 		}
 	}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -14,7 +14,8 @@ type Merge struct {
 	*cobra.Command
 
 	// cli args
-	DryRun bool
+	DryRun           bool
+	UnreleasedHeader string
 
 	// dependencies
 	ReadFile      shared.ReadFiler
@@ -58,12 +59,19 @@ Note that a newline is added between each version file.`,
 		false,
 		"Print merged changelog instead of writing to disk, will not run replacements",
 	)
+	cmd.Flags().StringVarP(
+		&m.UnreleasedHeader,
+		"include-unreleased", "u",
+		"",
+		"Include unreleased changes with this value as the header",
+	)
 
 	m.Command = cmd
 
 	return m
 }
 
+//nolint:gocyclo
 func (m *Merge) Run(cmd *cobra.Command, args []string) error {
 	config, err := core.LoadConfig(m.ReadFile)
 	if err != nil {
@@ -94,6 +102,40 @@ func (m *Merge) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		_ = core.WriteNewlines(writer, config.Newlines.AfterChangelogHeader)
+	}
+
+	if m.UnreleasedHeader != "" {
+		var unrelErr error
+
+		allChanges, unrelErr := core.GetChanges(
+			config,
+			nil,
+			m.ReadDir,
+			m.ReadFile,
+		)
+		if unrelErr != nil {
+			return unrelErr
+		}
+
+		// Make sure we have any changes before writing the unreleased content.
+		if len(allChanges) > 0 {
+			_ = core.WriteNewlines(writer, config.Newlines.BeforeChangelogVersion)
+			_, _ = writer.Write([]byte(m.UnreleasedHeader))
+
+			// create a fake batch to write the changes
+			b := &Batch{
+				config:        config,
+				writer:        writer,
+				TemplateCache: m.TemplateCache,
+			}
+
+			unrelErr = b.WriteChanges(allChanges)
+			if unrelErr != nil {
+				return unrelErr
+			}
+
+			_ = core.WriteNewlines(writer, config.Newlines.AfterChangelogVersion)
+		}
 	}
 
 	for _, version := range allVersions {


### PR DESCRIPTION
Closes #503

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
Any additional info that might help get your pull request merged.
