### PR TITLE
Fix slashes in FragmentFileFormat

### DIFF
--- a/.changes/unreleased/Fixed-20231023-152507.yaml
+++ b/.changes/unreleased/Fixed-20231023-152507.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Slashes in FragmentFileFormat resulting in unexpected file paths.
+time: 2023-10-23T15:25:07.485221383+01:00
+custom:
+  Issue: "559"

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -262,3 +262,45 @@ func TestErrorNewBadBody(t *testing.T) {
 	err := cmd.Run(cmd.Command, nil)
 	then.Err(t, mockErr, err)
 }
+
+func TestNewFragmentTemplateSlash(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Components = []string{"test/component"}
+	then.WithTempDirConfig(t, cfg)
+	reader, writer := then.WithReadWritePipe(t)
+
+	then.DelayWrite(
+		t, writer,
+		[]byte{106, 13},
+		[]byte{106, 13},
+		[]byte("a message"),
+		[]byte{13},
+	)
+
+	cmd := NewNew(
+		os.ReadFile,
+		os.Create,
+		newMockTime,
+		core.NewTemplateCache(),
+	)
+	cmd.SetIn(reader)
+
+	then.Nil(t, os.MkdirAll(filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir), 0755))
+
+	err := cmd.Run(cmd.Command, nil)
+	then.Nil(t, err)
+
+	futurePath := filepath.Join(cfg.ChangesDir, cfg.UnreleasedDir)
+	fileInfos, err := os.ReadDir(futurePath)
+	then.Nil(t, err)
+	then.Equals(t, 1, len(fileInfos))
+	then.Equals(t, ".yaml", filepath.Ext(fileInfos[0].Name()))
+
+	changeContent := fmt.Sprintf(
+		"component: test/component\nkind: removed\nbody: a message\ntime: %s\n",
+		newMockTime().Format(time.RFC3339Nano),
+	)
+
+	then.FileExists(t, futurePath, fileInfos[0].Name())
+	then.FileContents(t, changeContent, futurePath, fileInfos[0].Name())
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request.
Be sure to read the CONTRIBUTING guide.
-->

Closes #559

If the template for FragmentFileFormat resulted in any slashes being present in the final string the system would treat that as a nested directory under the "unreleased" directory.

This fixes that so that if slashes are in the final string they are first replaced with dashes to make a safe filename.

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
Any additional info that might help get your pull request merged.
