### PR TITLE
Allow for VersionNoPrefix in VersionFormat

### DIFF
--- a/.changes/unreleased/Added-20231213-192317.yaml
+++ b/.changes/unreleased/Added-20231213-192317.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: VersionNoFormat can be used in the VersionFormat configuration
+time: 2023-12-13T19:23:17.487472-05:00
+custom:
+  Issue: "586"

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -202,6 +202,7 @@ func (b *Batch) getBatchData() (*core.BatchData, error) {
 	return &core.BatchData{
 		Time:            b.TimeNow(),
 		Version:         currentVersion.Original(),
+		VersionNoPrefix: currentVersion.String(),
 		PreviousVersion: previousVersion.Original(),
 		Major:           int(currentVersion.Major()),
 		Minor:           int(currentVersion.Minor()),

--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -240,6 +240,7 @@ func TestBatchComplexVersion(t *testing.T) {
 * [{{.}}](https://github.com/{{.}})
 {{- end}}
 env: {{.Env.ENV_KEY}}`
+	cfg.VersionFormat = "## {{.VersionNoPrefix}}"
 
 	then.WithTempDirConfig(t, cfg)
 	t.Setenv("TEST_CHANGIE_ENV_KEY", "env value")
@@ -273,7 +274,7 @@ env: {{.Env.ENV_KEY}}`
 	err := batch.Run(batch.Command, []string{"v0.2.0"})
 	then.Nil(t, err)
 
-	verContents := `## v0.2.0-b1+hash
+	verContents := `## 0.2.0-b1+hash
 2 changes this release
 ### added
 * D by miniscruff

--- a/core/templatecache.go
+++ b/core/templatecache.go
@@ -19,6 +19,8 @@ type BatchData struct {
 	Time time.Time
 	// Version of the change, will include "v" prefix if used
 	Version string
+	// Version of the release without the "v" prefix if used
+	VersionNoPrefix string
 	// Previous released version
 	PreviousVersion string
 	// Major value of the version


### PR DESCRIPTION
VersionNoPrefix can now be included in the VersionFormat (`## {{.VersionNoPrefix}}`) so a change can look like `## 2.0.1` instead of `## v2.0.1`.

Closes #586

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
Any additional info that might help get your pull request merged.
