### PR TITLE
fix: Avoid deprecated properties in goreleaser integration config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,4 +84,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  skip: false
+  disable: false

--- a/docs/content/integrations/goreleaser.md
+++ b/docs/content/integrations/goreleaser.md
@@ -12,7 +12,7 @@ First make sure GoReleaser will even generate any changelog by setting skip to f
 
 ```yaml
 changelog:
-  skip: false
+  disable: false
 ```
 
 By default GoReleaser expects to release the current tag but we can let GitHub


### PR DESCRIPTION
`changelog.skip` has been deprecated in favor of `changelog.disable` since 2024-01-14

cf. https://goreleaser.com/deprecations/#changelogskip

<!--
Thanks for submitting a pull request.
Be sure to read the CONTRIBUTING guide.
-->

**Check the following**
- [x] Keep 100% code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
Any additional info that might help get your pull request merged.
