### PR TITLE
Create destination directoy for CLI docs if it does not exist

### DIFF
--- a/cmd/gen_test.go
+++ b/cmd/gen_test.go
@@ -41,6 +41,10 @@ func TestCanGetFiles(t *testing.T) {
 	// ignore any bad error trying to remove the file, it may not exist and that is ok
 	_ = os.Remove(configDocsPath)
 
+	// create cli docs directory if it does not already exist
+	err = os.MkdirAll(cliDocsPath, os.ModePerm)
+	then.Nil(t, err)
+
 	cliDocsFiles, err := os.ReadDir(cliDocsPath)
 	then.Nil(t, err)
 


### PR DESCRIPTION
Closes #723.

**Additional context**
This MR just creates the directory. If it already exists, the operation is skipped silently.
