### PR TITLE
Support go templates in kinds.auto

### DIFF
--- a/.changes/unreleased/added-20260623-092949.yaml
+++ b/.changes/unreleased/added-20260623-092949.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Support go templates in kinds.auto
+time: 2026-06-23T09:29:49.6974979+02:00

--- a/.changes/unreleased/added-20260623-092949.yaml
+++ b/.changes/unreleased/added-20260623-092949.yaml
@@ -1,3 +1,0 @@
-kind: added
-body: Support go templates in kinds.auto
-time: 2026-06-23T09:29:49.6974979+02:00

--- a/.changes/unreleased/added-20260627-122153.yaml
+++ b/.changes/unreleased/added-20260627-122153.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: Support templating in kinds auto
+time: 2026-06-27T12:21:53.282335025-07:00
+custom:
+    Issue: "902"

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -180,6 +180,7 @@ func (b *Batch) getBatchData() (*core.BatchData, error) {
 
 	currentVersion, err := core.GetNextVersion(
 		b.config,
+		b.TemplateCache,
 		b.version,
 		b.Prerelease,
 		b.Meta,

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -16,10 +16,14 @@ type Next struct {
 	Prerelease  []string
 	Meta        []string
 	Project     string
+
+	TemplateCache *core.TemplateCache
 }
 
-func NewNext() *Next {
-	next := &Next{}
+func NewNext(cache *core.TemplateCache) *Next {
+	next := &Next{
+		TemplateCache: cache,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "next major|minor|patch|auto",
@@ -95,7 +99,7 @@ func (n *Next) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	next, err := core.GetNextVersion(config, part, n.Prerelease, n.Meta, changes, n.Project)
+	next, err := core.GetNextVersion(config, n.TemplateCache, part, n.Prerelease, n.Meta, changes, n.Project)
 	if err != nil {
 		return err
 	}

--- a/cmd/next_test.go
+++ b/cmd/next_test.go
@@ -27,7 +27,7 @@ func TestNextVersionWithPatch(t *testing.T) {
 	cfg := nextTestConfig()
 	then.WithTempDirConfig(t, cfg)
 
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	builder := strings.Builder{}
 
 	next.SetOut(&builder)
@@ -55,7 +55,7 @@ func TestNextVersionWithProject(t *testing.T) {
 	then.WithTempDirConfig(t, cfg)
 
 	builder := strings.Builder{}
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	next.Project = "w"
 
 	next.SetOut(&builder)
@@ -83,7 +83,7 @@ func TestNextVersionWithProjectBadProject(t *testing.T) {
 	then.WithTempDirConfig(t, cfg)
 
 	builder := strings.Builder{}
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	next.Project = "missing_proj"
 
 	next.SetOut(&builder)
@@ -110,7 +110,7 @@ func TestNextVersionWithAuto(t *testing.T) {
 	then.WithTempDirConfig(t, cfg)
 
 	builder := strings.Builder{}
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 
 	next.SetOut(&builder)
 	then.CreateFile(t, cfg.ChangesDir, "v0.0.1.md")
@@ -135,7 +135,7 @@ func TestNextVersionWithPrereleaseAndMeta(t *testing.T) {
 	cfg := nextTestConfig()
 	then.WithTempDirConfig(t, cfg)
 
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	builder := strings.Builder{}
 
 	next.Prerelease = []string{"b1"}
@@ -157,7 +157,7 @@ func TestNextVersionWithoutAnyChangesIsV1(t *testing.T) {
 
 	builder := strings.Builder{}
 
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	next.SetOut(&builder)
 
 	err := next.Run(next.Command, []string{"major"})
@@ -168,7 +168,7 @@ func TestNextVersionWithoutAnyChangesIsV1(t *testing.T) {
 func TestErrorNextVersionBadConfig(t *testing.T) {
 	then.WithTempDir(t)
 
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	builder := strings.Builder{}
 
 	next.SetOut(&builder)
@@ -181,7 +181,7 @@ func TestErrorNextPartNotSupported(t *testing.T) {
 	cfg := nextTestConfig()
 	then.WithTempDirConfig(t, cfg)
 
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	builder := strings.Builder{}
 
 	next.SetOut(&builder)
@@ -195,7 +195,7 @@ func TestErrorNextUnableToGetChanges(t *testing.T) {
 	cfg := nextTestConfig()
 	then.WithTempDirConfig(t, cfg)
 
-	next := NewNext()
+	next := NewNext(core.NewTemplateCache())
 	builder := strings.Builder{}
 	aVer := []byte("not a valid change")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ being easy to use for developers and your release team.`,
 	cmd.AddCommand(NewLatest().Command)
 	cmd.AddCommand(merge.Command)
 	cmd.AddCommand(NewNew(time.Now, templateCache).Command)
-	cmd.AddCommand(NewNext().Command)
+	cmd.AddCommand(NewNext(templateCache).Command)
 	cmd.AddCommand(NewDiff().Command)
 
 	return cmd

--- a/core/config.go
+++ b/core/config.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
@@ -32,6 +33,7 @@ var ConfigPaths []string = []string{
 }
 
 var ErrConfigNotFound = errors.New("no changie config found")
+var ErrInvalidAutoLevel = errors.New("auto level template must resolve to major, minor, patch or none")
 
 // GetVersions will return, in semver sorted order, all released versions
 type GetVersions func(Config) ([]*semver.Version, error)
@@ -69,9 +71,12 @@ type KindConfig struct {
 	// Possible values are major, minor, patch or none and the highest one is used if
 	// multiple changes are found. none will not bump the version.
 	// Only none changes is not a valid bump and will fail to batch.
+	// Auto also supports go templates using the change as the template data, so the
+	// level can be calculated from custom values. The rendered value must be one of
+	// the possible values listed above.
 	// example: yaml
-	// auto: minor
-	AutoLevel string `yaml:"auto,omitempty"`
+	// auto: '{{if eq .Custom.Breaking "Yes"}}major{{else}}patch{{end}}'
+	AutoLevel string `yaml:"auto,omitempty" templateType:"Change"`
 }
 
 // KeyOrLabel returns the kind config key if set, otherwise the label
@@ -81,6 +86,32 @@ func (kc *KindConfig) KeyOrLabel() string {
 	}
 
 	return kc.Label
+}
+
+// AutoLevelForChange resolves the auto bump level for the provided change.
+// The auto value supports go templates using the change as the template data,
+// so the level can be derived from custom values.
+// If auto does not contain a template it is returned as-is. When a template is
+// used, the rendered value is validated to be one of major, minor, patch or none;
+// anything else is an error so typos do not silently no-op. As with every other
+// changie template, whitespace is the caller's responsibility via the {{- / -}}
+// trim markers, so the rendered value is used verbatim and not trimmed.
+func (kc *KindConfig) AutoLevelForChange(cache *TemplateCache, change Change) (string, error) {
+	if !strings.Contains(kc.AutoLevel, "{{") {
+		return kc.AutoLevel, nil
+	}
+
+	level, err := cache.ExecuteString(kc.AutoLevel, change)
+	if err != nil {
+		return EmptyLevel, err
+	}
+
+	switch level {
+	case MajorLevel, MinorLevel, PatchLevel, NoneLevel:
+		return level, nil
+	default:
+		return EmptyLevel, fmt.Errorf("%w: kind %q rendered %q", ErrInvalidAutoLevel, kc.KeyOrLabel(), level)
+	}
 }
 
 // Body config allows you to customize the default body prompt

--- a/core/config.go
+++ b/core/config.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
@@ -32,8 +31,10 @@ var ConfigPaths []string = []string{
 	".changie.yml",
 }
 
-var ErrConfigNotFound = errors.New("no changie config found")
-var ErrInvalidAutoLevel = errors.New("auto level template must resolve to major, minor, patch or none")
+var (
+	ErrConfigNotFound   = errors.New("no changie config found")
+	ErrInvalidAutoLevel = errors.New("auto level must resolve to major, minor, patch or none")
+)
 
 // GetVersions will return, in semver sorted order, all released versions
 type GetVersions func(Config) ([]*semver.Version, error)
@@ -91,14 +92,9 @@ func (kc *KindConfig) KeyOrLabel() string {
 // AutoLevelForChange resolves the auto bump level for the provided change.
 // The auto value supports go templates using the change as the template data,
 // so the level can be derived from custom values.
-// If auto does not contain a template it is returned as-is. When a template is
-// used, the rendered value is validated to be one of major, minor, patch or none;
-// anything else is an error so typos do not silently no-op. As with every other
-// changie template, whitespace is the caller's responsibility via the {{- / -}}
-// trim markers, so the rendered value is used verbatim and not trimmed.
 func (kc *KindConfig) AutoLevelForChange(cache *TemplateCache, change Change) (string, error) {
-	if !strings.Contains(kc.AutoLevel, "{{") {
-		return kc.AutoLevel, nil
+	if kc.AutoLevel == "" {
+		return EmptyLevel, ErrMissingAutoLevel
 	}
 
 	level, err := cache.ExecuteString(kc.AutoLevel, change)
@@ -110,7 +106,7 @@ func (kc *KindConfig) AutoLevelForChange(cache *TemplateCache, change Change) (s
 	case MajorLevel, MinorLevel, PatchLevel, NoneLevel:
 		return level, nil
 	default:
-		return EmptyLevel, fmt.Errorf("%w: kind %q rendered %q", ErrInvalidAutoLevel, kc.KeyOrLabel(), level)
+		return EmptyLevel, fmt.Errorf("kind %q wit auto config %q: %w", kc.KeyOrLabel(), kc.AutoLevel, ErrInvalidAutoLevel)
 	}
 }
 

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -450,3 +450,54 @@ func TestConfigProjectErrorNotFound(t *testing.T) {
 	_, err := cfg.Project("emailer")
 	then.Err(t, errProjectNotFound, err)
 }
+
+func TestAutoLevelForChangeLiteral(t *testing.T) {
+	kc := KindConfig{AutoLevel: MinorLevel}
+	level, err := kc.AutoLevelForChange(NewTemplateCache(), Change{})
+	then.Nil(t, err)
+	then.Equals(t, MinorLevel, level)
+}
+
+func TestAutoLevelForChangeTemplate(t *testing.T) {
+	kc := KindConfig{
+		AutoLevel: `{{if eq .Custom.Breaking "Yes"}}major{{else}}patch{{end}}`,
+	}
+	cache := NewTemplateCache()
+
+	major, err := kc.AutoLevelForChange(cache, Change{Custom: map[string]string{"Breaking": "Yes"}})
+	then.Nil(t, err)
+	then.Equals(t, MajorLevel, major)
+
+	patch, err := kc.AutoLevelForChange(cache, Change{Custom: map[string]string{"Breaking": "No"}})
+	then.Nil(t, err)
+	then.Equals(t, PatchLevel, patch)
+}
+
+func TestAutoLevelForChangeNoneTemplate(t *testing.T) {
+	kc := KindConfig{AutoLevel: `{{if .Custom.Skip}}none{{else}}patch{{end}}`}
+	cache := NewTemplateCache()
+
+	none, err := kc.AutoLevelForChange(cache, Change{Custom: map[string]string{"Skip": "true"}})
+	then.Nil(t, err)
+	then.Equals(t, NoneLevel, none)
+}
+
+func TestAutoLevelForChangeBadTemplate(t *testing.T) {
+	kc := KindConfig{AutoLevel: "{{ no_such_func }}"}
+	_, err := kc.AutoLevelForChange(NewTemplateCache(), Change{})
+	then.NotNil(t, err)
+}
+
+// A template that renders an unknown level (typo / wrong case) must error, not no-op.
+func TestErrorAutoLevelForChangeInvalidRender(t *testing.T) {
+	kc := KindConfig{AutoLevel: `{{ "Major" }}`}
+	_, err := kc.AutoLevelForChange(NewTemplateCache(), Change{})
+	then.NotNil(t, err)
+}
+
+// A conditional with no else renders empty and must error clearly.
+func TestErrorAutoLevelForChangeEmptyRender(t *testing.T) {
+	kc := KindConfig{AutoLevel: `{{if .Custom.Breaking}}major{{end}}`}
+	_, err := kc.AutoLevelForChange(NewTemplateCache(), Change{})
+	then.NotNil(t, err)
+}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -492,7 +492,7 @@ func TestAutoLevelForChangeBadTemplate(t *testing.T) {
 func TestErrorAutoLevelForChangeInvalidRender(t *testing.T) {
 	kc := KindConfig{AutoLevel: `{{ "Major" }}`}
 	_, err := kc.AutoLevelForChange(NewTemplateCache(), Change{})
-	then.NotNil(t, err)
+	then.Err(t, ErrInvalidAutoLevel, err)
 }
 
 // A conditional with no else renders empty and must error clearly.

--- a/core/utils.go
+++ b/core/utils.go
@@ -119,14 +119,12 @@ func ValidBumpLevel(level string) bool {
 		level == AutoLevel
 }
 
-func HighestAutoLevel(config *Config, allChanges []Change) (string, error) {
+func HighestAutoLevel(config *Config, cache *TemplateCache, allChanges []Change) (string, error) {
 	if len(allChanges) == 0 {
 		return "", ErrNoChangesFoundForAuto
 	}
 
-	templateCache := NewTemplateCache()
 	highestLevel := EmptyLevel
-	err := ErrNoChangesFoundForAuto
 
 	for _, change := range allChanges {
 		for _, kc := range config.Kinds {
@@ -134,9 +132,9 @@ func HighestAutoLevel(config *Config, allChanges []Change) (string, error) {
 				continue
 			}
 
-			level, levelErr := kc.AutoLevelForChange(templateCache, change)
-			if levelErr != nil {
-				return EmptyLevel, levelErr
+			level, err := kc.AutoLevelForChange(cache, change)
+			if err != nil {
+				return EmptyLevel, err
 			}
 
 			switch level {
@@ -146,13 +144,11 @@ func HighestAutoLevel(config *Config, allChanges []Change) (string, error) {
 			case PatchLevel:
 				if highestLevel == EmptyLevel {
 					highestLevel = PatchLevel
-					err = nil
 				}
 			case MinorLevel:
 				// bump to minor if we have a minor level
 				if highestLevel == PatchLevel || highestLevel == EmptyLevel {
 					highestLevel = MinorLevel
-					err = nil
 				}
 			case EmptyLevel:
 				return EmptyLevel, ErrMissingAutoLevel
@@ -160,11 +156,16 @@ func HighestAutoLevel(config *Config, allChanges []Change) (string, error) {
 		}
 	}
 
-	return highestLevel, err
+	if highestLevel == EmptyLevel {
+		return EmptyLevel, ErrNoChangesFoundForAuto
+	}
+
+	return highestLevel, nil
 }
 
 func GetNextVersion(
 	config *Config,
+	cache *TemplateCache,
 	partOrVersion string,
 	prerelease, meta []string,
 	allChanges []Change,
@@ -190,7 +191,7 @@ func GetNextVersion(
 		}
 
 		if partOrVersion == AutoLevel {
-			partOrVersion, err = HighestAutoLevel(config, allChanges)
+			partOrVersion, err = HighestAutoLevel(config, cache, allChanges)
 			if err != nil {
 				return nil, err
 			}

--- a/core/utils.go
+++ b/core/utils.go
@@ -124,6 +124,7 @@ func HighestAutoLevel(config *Config, allChanges []Change) (string, error) {
 		return "", ErrNoChangesFoundForAuto
 	}
 
+	templateCache := NewTemplateCache()
 	highestLevel := EmptyLevel
 	err := ErrNoChangesFoundForAuto
 
@@ -133,7 +134,12 @@ func HighestAutoLevel(config *Config, allChanges []Change) (string, error) {
 				continue
 			}
 
-			switch kc.AutoLevel {
+			level, levelErr := kc.AutoLevelForChange(templateCache, change)
+			if levelErr != nil {
+				return EmptyLevel, levelErr
+			}
+
+			switch level {
 			case MajorLevel:
 				// major is the highest one, so we can just return it
 				return MajorLevel, nil

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -160,7 +160,7 @@ func TestErrorNextVersionBadReadDir(t *testing.T) {
 
 	config := &Config{ChangesDir: "\\."}
 
-	ver, err := GetNextVersion(config, "major", nil, nil, nil, "")
+	ver, err := GetNextVersion(config, NewTemplateCache(), "major", nil, nil, nil, "")
 	then.Equals(t, "v1.0.0", ver.Original())
 	then.Nil(t, err)
 }
@@ -171,7 +171,7 @@ func TestErrorNextVersionBadVersion(t *testing.T) {
 
 	config := &Config{ChangesDir: "."}
 
-	ver, err := GetNextVersion(config, "a", []string{}, []string{}, nil, "")
+	ver, err := GetNextVersion(config, NewTemplateCache(), "a", []string{}, []string{}, nil, "")
 	then.Equals(t, ver, nil)
 	then.Err(t, ErrBadVersionOrPart, err)
 }
@@ -253,7 +253,7 @@ func TestNextVersionOptions(t *testing.T) {
 				ChangesDir: ".",
 			}
 
-			ver, err := GetNextVersion(config, tc.partOrVersion, tc.prerelease, tc.meta, nil, "")
+			ver, err := GetNextVersion(config, NewTemplateCache(), tc.partOrVersion, tc.prerelease, tc.meta, nil, "")
 			then.Nil(t, err)
 			then.Equals(t, tc.expected, ver.Original())
 		})
@@ -298,7 +298,7 @@ func TestNextVersionOptionsWithNoneAutoLevel(t *testing.T) {
 		},
 	}
 
-	ver, err := GetNextVersion(config, "auto", nil, nil, changes, "")
+	ver, err := GetNextVersion(config, NewTemplateCache(), "auto", nil, nil, changes, "")
 	then.Nil(t, err)
 	then.Equals(t, "v0.3.0", ver.Original())
 }
@@ -325,7 +325,7 @@ func TestNextVersionOptionsNoneAutoLevelOnly(t *testing.T) {
 		},
 	}
 
-	ver, err := GetNextVersion(config, "auto", nil, nil, changes, "")
+	ver, err := GetNextVersion(config, NewTemplateCache(), "auto", nil, nil, changes, "")
 	then.Equals(t, ver, nil)
 	then.Err(t, ErrNoChangesFoundForAuto, err)
 }
@@ -350,7 +350,7 @@ func TestErrorNextVersionAutoMissingKind(t *testing.T) {
 		},
 	}
 
-	_, err = GetNextVersion(config, "auto", nil, nil, changes, "")
+	_, err = GetNextVersion(config, NewTemplateCache(), "auto", nil, nil, changes, "")
 	then.Err(t, ErrMissingAutoLevel, err)
 }
 
@@ -360,7 +360,7 @@ func TestErrorNextVersionBadPrerelease(t *testing.T) {
 
 	config := &Config{ChangesDir: "."}
 
-	_, err := GetNextVersion(config, "patch", []string{"0005"}, nil, nil, "")
+	_, err := GetNextVersion(config, NewTemplateCache(), "patch", []string{"0005"}, nil, nil, "")
 	then.NotNil(t, err)
 }
 
@@ -370,7 +370,7 @@ func TestErrorNextVersionBadMeta(t *testing.T) {
 
 	config := &Config{ChangesDir: "."}
 
-	_, err := GetNextVersion(config, "patch", nil, []string{"&&*&"}, nil, "")
+	_, err := GetNextVersion(config, NewTemplateCache(), "patch", nil, []string{"&&*&"}, nil, "")
 	then.NotNil(t, err)
 }
 
@@ -556,7 +556,7 @@ func TestHighestAutoLevel(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := HighestAutoLevel(cfg, tc.changes)
+			res, err := HighestAutoLevel(cfg, NewTemplateCache(), tc.changes)
 			then.Nil(t, err)
 			then.Equals(t, tc.expected, res)
 		})
@@ -576,7 +576,7 @@ func TestErrorHighestAutoLevelMissingKindConfig(t *testing.T) {
 			Kind: "missing",
 		},
 	}
-	_, err := HighestAutoLevel(cfg, changes)
+	_, err := HighestAutoLevel(cfg, NewTemplateCache(), changes)
 	then.Err(t, ErrMissingAutoLevel, err)
 }
 
@@ -589,7 +589,7 @@ func TestErrorHighestAutoLevelWithNoChanges(t *testing.T) {
 		},
 	}
 	changes := []Change{}
-	_, err := HighestAutoLevel(cfg, changes)
+	_, err := HighestAutoLevel(cfg, NewTemplateCache(), changes)
 	then.Err(t, ErrNoChangesFoundForAuto, err)
 }
 
@@ -799,13 +799,13 @@ func TestHighestAutoLevelWithTemplate(t *testing.T) {
 		},
 	}
 
-	major, err := HighestAutoLevel(cfg, []Change{
+	major, err := HighestAutoLevel(cfg, NewTemplateCache(), []Change{
 		{Kind: "changed", Custom: map[string]string{"Breaking": "Yes"}},
 	})
 	then.Nil(t, err)
 	then.Equals(t, MajorLevel, major)
 
-	patch, err := HighestAutoLevel(cfg, []Change{
+	patch, err := HighestAutoLevel(cfg, NewTemplateCache(), []Change{
 		{Kind: "changed", Custom: map[string]string{"Breaking": "No"}},
 	})
 	then.Nil(t, err)
@@ -818,7 +818,7 @@ func TestErrorHighestAutoLevelBadTemplate(t *testing.T) {
 			{Label: "changed", AutoLevel: "{{ no_such_func }}"},
 		},
 	}
-	_, err := HighestAutoLevel(cfg, []Change{{Kind: "changed"}})
+	_, err := HighestAutoLevel(cfg, NewTemplateCache(), []Change{{Kind: "changed"}})
 	then.NotNil(t, err)
 }
 
@@ -830,6 +830,6 @@ func TestErrorHighestAutoLevelInvalidRender(t *testing.T) {
 			{Label: "changed", AutoLevel: `{{ "nope" }}`},
 		},
 	}
-	_, err := HighestAutoLevel(cfg, []Change{{Kind: "changed"}})
+	_, err := HighestAutoLevel(cfg, NewTemplateCache(), []Change{{Kind: "changed"}})
 	then.Err(t, ErrInvalidAutoLevel, err)
 }

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -788,3 +788,48 @@ type errRunner struct {
 func (r *errRunner) Run() error {
 	return r.err
 }
+
+func TestHighestAutoLevelWithTemplate(t *testing.T) {
+	cfg := &Config{
+		Kinds: []KindConfig{
+			{
+				Label:     "changed",
+				AutoLevel: `{{if eq .Custom.Breaking "Yes"}}major{{else}}patch{{end}}`,
+			},
+		},
+	}
+
+	major, err := HighestAutoLevel(cfg, []Change{
+		{Kind: "changed", Custom: map[string]string{"Breaking": "Yes"}},
+	})
+	then.Nil(t, err)
+	then.Equals(t, MajorLevel, major)
+
+	patch, err := HighestAutoLevel(cfg, []Change{
+		{Kind: "changed", Custom: map[string]string{"Breaking": "No"}},
+	})
+	then.Nil(t, err)
+	then.Equals(t, PatchLevel, patch)
+}
+
+func TestErrorHighestAutoLevelBadTemplate(t *testing.T) {
+	cfg := &Config{
+		Kinds: []KindConfig{
+			{Label: "changed", AutoLevel: "{{ no_such_func }}"},
+		},
+	}
+	_, err := HighestAutoLevel(cfg, []Change{{Kind: "changed"}})
+	then.NotNil(t, err)
+}
+
+// A single change whose template renders an invalid level must return a clear
+// ErrInvalidAutoLevel, NOT the misleading ErrNoChangesFoundForAuto.
+func TestErrorHighestAutoLevelInvalidRender(t *testing.T) {
+	cfg := &Config{
+		Kinds: []KindConfig{
+			{Label: "changed", AutoLevel: `{{ "nope" }}`},
+		},
+	}
+	_, err := HighestAutoLevel(cfg, []Change{{Kind: "changed"}})
+	then.Err(t, ErrInvalidAutoLevel, err)
+}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -812,18 +812,6 @@ func TestHighestAutoLevelWithTemplate(t *testing.T) {
 	then.Equals(t, PatchLevel, patch)
 }
 
-func TestErrorHighestAutoLevelBadTemplate(t *testing.T) {
-	cfg := &Config{
-		Kinds: []KindConfig{
-			{Label: "changed", AutoLevel: "{{ no_such_func }}"},
-		},
-	}
-	_, err := HighestAutoLevel(cfg, NewTemplateCache(), []Change{{Kind: "changed"}})
-	then.NotNil(t, err)
-}
-
-// A single change whose template renders an invalid level must return a clear
-// ErrInvalidAutoLevel, NOT the misleading ErrNoChangesFoundForAuto.
 func TestErrorHighestAutoLevelInvalidRender(t *testing.T) {
 	cfg := &Config{
 		Kinds: []KindConfig{

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -117,7 +117,7 @@
         },
         "auto": {
           "type": "string",
-          "description": "Auto determines what value to bump when using `batch auto` or `next auto`.\nPossible values are major, minor, patch or none and the highest one is used if\nmultiple changes are found. none will not bump the version.\nOnly none changes is not a valid bump and will fail to batch.\nexample: yaml\nauto: minor"
+          "description": "Auto determines what value to bump when using `batch auto` or `next auto`.\nPossible values are major, minor, patch or none and the highest one is used if\nmultiple changes are found. none will not bump the version.\nOnly none changes is not a valid bump and will fail to batch.\nAuto also supports go templates using the change as the template data, so the\nlevel can be calculated from custom values. The rendered value must be one of\nthe possible values listed above.\nexample: yaml\nauto: '{{if eq .Custom.Breaking \"Yes\"}}major{{else}}patch{{end}}'"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Implements the [second approach](https://github.com/miniscruff/changie/discussions/509#discussioncomment-17020329) of #509

Fixes #902 

**Check the following**
- [x] Maintain high code coverage
- [x] Be properly formatted
- [x] Documentation changes are included
- [x] Include a change file if expected

**Additional context**
I'm not a go developer. Please be patient and review the changes carefully.