### PR TITLE
Sign release checksums with Cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
         node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Setup Cosign
+      uses: sigstore/cosign-installer@v4.1.2
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v4.2.0
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,15 @@ dockers:
     - "--platform=linux/amd64"
 checksum:
   name_template: 'checksums.txt'
+signs:
+  - artifacts: checksum
+    signature: ${artifact}.sigstore.json
+    cmd: cosign
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - --yes
+      - ${artifact}
 snapshot:
   version_template: "{{ .Tag }}-next"
 changelog:


### PR DESCRIPTION
Refs
- https://www.sigstore.dev
- https://docs.sigstore.dev/cosign/signing/overview/
- https://github.com/sigstore/cosign
- https://goreleaser.com/customization/sign/sign/#signing-with-cosign

This yields a checksums.txt.sigstore.json in release assets, which can be used to verify the checksums file and thus transitively files listed in it. This can be done manually using cosign, and software such as aqua and mise can do it automatically on install.

<!--
Thanks for submitting a pull request.
Be sure to read the CONTRIBUTING guide.
-->

~Closes #NNN~

**Check the following**
- [ ] Maintain high code coverage
- [x] Be properly formatted
- [ ] Documentation changes are included
- [ ] Include a change file if expected

**Additional context**

Note: with this, one likely wants to use --skip=sign if running goreleaser release --snapshot to test (other) things locally.

Caveat: untested, but have set this up for multiple projects, one recent sample at https://github.com/daveshanley/vacuum/pull/927
